### PR TITLE
DTSPO-6345  NFDIV - Remove NFDIV entry as not currently deployed in prod

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -87,9 +87,6 @@ parameters:
       - name: 'fact'
         shutter: 'default'
         subscription: DCD-CFTAPPS-PROD
-      - name: 'nfdiv'
-        shutter: 'default'
-        subscription: DCD-CFTAPPS-PROD
       - name: 'jdbureau'
         shutter: 'default'
         subscription: DTS-SHAREDSERVICES-PROD


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-6345


### Change description ###
Azure-shutter-pages pipeline currently fails at the NFDIV stage due to the missing storage account.  NFDIV is not currently deployed in production and should not have a shutter page.  

Though specified to use the default shutter page, a storage account is still required to be created as files will be copied from the default location to the storage account.  The required storage account likely never existed in the first place and the shutter page entry was previously created under PR #26 .

Entry now being removed to unblock pipeline and can be restored when NFDIV is being deployed in production (this will also require adding NFDIV to the [Azure-Terraform-Pipeline](https://github.com/hmcts/azure-platform-terraform/blob/master/environments/prod/prod.tfvars) to have the required infrastructure shutter resources created)


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
