### PR TITLE
Amend 'sptribs' default shutter name to 8 characters

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -102,7 +102,7 @@ parameters:
       - name: 'etsya'
         shutter: 'etsya'
         subscription: DCD-CFTAPPS-PROD
-      - name: 'sptribsfrontend'
+      - name: 'sptribsf'
         shutter: 'default'
         subscription: DCD-CFTAPPS-PROD
       - name: 'jdbureau'


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ST-1365


### Change description ###
Amend 'sptribs' default shutter name to 8 characters as fix for CDN storage account content missing.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
