### PR TITLE
fix: switch child-adoption to custom shutter page

### DIFF
--- a/.github/workflows/child-adoption.yaml
+++ b/.github/workflows/child-adoption.yaml
@@ -26,6 +26,6 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     uses: hmcts/azure-shutter-pages/.github/workflows/deploy-shutter-pages.yaml@master
     with:
-      shutter_page_folder: "default" # App source code path relative to repository root. Enter "default" for default pages.
+      shutter_page_folder: "child-adoption" # App source code path relative to repository root. Enter "default" for default pages.
     secrets:
       WEBAPP_TOKEN: ${{ secrets.CHILD_ADOPTION_PROD }}


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15305


### Change description ###
Updated shutter_page_folder to point to the child-adoption specific shutter page.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
