### PR TITLE
DTSPO-22779 Adding darts portal with a default shutter page

### DIFF
--- a/.github/workflows/darts-portal.yaml
+++ b/.github/workflows/darts-portal.yaml
@@ -1,0 +1,31 @@
+name: push shutter page to darts-portal static webapp
+run-name: ${{ github.ref_name }} ${{ github.actor }}
+
+on:
+  workflow_dispatch:
+  check_run:
+    types:
+      - completed
+  push:
+    branches:
+      - master
+    paths:
+      - 'default/**'
+      - .github/workflows/darts-portal.yaml
+
+  pull_request:
+    types: [opened]
+    branches:
+      - master
+    paths:
+      - 'default/**'
+      - .github/workflows/darts-portal.yaml
+
+jobs:
+  build_and_deploy_job:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    uses: hmcts/azure-shutter-pages/.github/workflows/deploy-shutter-pages.yaml@master
+    with:
+      shutter_page_folder: "default" # App source code path relative to repository root. Enter "default" for default pages.
+    secrets:
+      WEBAPP_TOKEN: ${{ secrets.DARTS_PORTAL_PROD }}


### PR DESCRIPTION
### Jira link

[DTSPO-22779](https://tools.hmcts.net/jira/browse/DTSPO-22779)

### Change description

Notice darts-portal has a static web app but no shutter page created for it.  Making this change to add a default static page for darts-portal

